### PR TITLE
Throw exceptions for token generation errors and improve tests

### DIFF
--- a/src/Fintecture.php
+++ b/src/Fintecture.php
@@ -4,6 +4,7 @@ namespace Bnzo\Fintecture;
 
 use Bnzo\Fintecture\DTO\ConfigDTO;
 use Fintecture\PisClient;
+use Fintecture\Util\FintectureException;
 use Psr\Http\Client\ClientInterface;
 
 class Fintecture
@@ -23,7 +24,7 @@ class Fintecture
         if (! $pisToken->error) {
             $this->pisClient->setAccessToken($pisToken); // set token of PIS client
         } else {
-            echo $pisToken->errorMsg;
+            throw new FintectureException($pisToken->errorMsg);
         }
 
         $payload = [
@@ -55,7 +56,7 @@ class Fintecture
         if (! $connect->error) {
             return $connect->meta->url; // @phpstan-ignore-line
         } else {
-            echo $connect->errorMsg;
+            throw new FintectureException($connect->errorMsg);
         }
     }
 }

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Bnzo\Fintecture\Facades\Fintecture;
+use Bnzo\Fintecture\Tests\FintectureTester;
+use Fintecture\Util\FintectureException;
+use GuzzleHttp\Psr7\Response;
+
+it('can throw an exception if token generation fails', function () {
+    FintectureTester::mockResponses([
+        new Response(
+            status: 400,
+            body: json_encode(['status' => '400', 'errors' => [
+                [
+                    'code' => 'mock_error_code',
+                    'title' => 'mock_error_title',
+                    'message' => 'mock_error_message',
+                ],
+            ]])
+        ),
+    ], withToken: false);
+
+    $url = Fintecture::generate();
+
+    expect($url)->toBe('https://mock.url/fintecture');
+})->throws(FintectureException::class, 'mock_error_message');

--- a/tests/FintectureTester.php
+++ b/tests/FintectureTester.php
@@ -4,13 +4,19 @@ namespace Bnzo\Fintecture\Tests;
 
 use Bnzo\Fintecture\DTO\ConfigDTO;
 use Bnzo\Fintecture\Fintecture;
+use GuzzleHttp\Psr7\Response;
+use Http\Message\RequestMatcher\RequestMatcher;
 use Http\Mock\Client;
 
 class FintectureTester
 {
-    public static function mockResponses(array $responses)
+    public static function mockResponses(array $responses, bool $withToken = true)
     {
         $client = new Client;
+
+        if ($withToken) {
+            $client = self::withToken($client);
+        }
 
         foreach ($responses as $response) {
             $client->addResponse($response);
@@ -28,5 +34,18 @@ class FintectureTester
 
             return new Fintecture($configDTO, $client);
         });
+    }
+
+    public static function withToken(Client $client): Client
+    {
+        $requestMatcher = new RequestMatcher(path: 'oauth/accesstoken');
+
+        $response = new Response(
+            body: json_encode(['access_token' => 'mock_access_token'])
+        );
+
+        $client->on($requestMatcher, $response);
+
+        return $client;
     }
 }

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -2,23 +2,39 @@
 
 use Bnzo\Fintecture\Facades\Fintecture;
 use Bnzo\Fintecture\Tests\FintectureTester;
+use Fintecture\Util\FintectureException;
 use GuzzleHttp\Psr7\Response;
 
-it('can generate', function () {
+it('can generate url', function () {
     FintectureTester::mockResponses([
         new Response(
-            body: json_encode(['access_token' => 'mock_access_token'])
-        ),
-        new Response(
-
             body: json_encode(['meta' => [
                 'url' => 'https://mock.url/fintecture',
                 'session_id' => 'mock_session_id',
-            ]], )
+            ]])
+        ),
+    ], );
+
+    $url = Fintecture::generate();
+
+    expect($url)->toBe('https://mock.url/fintecture');
+});
+
+it('can throw an exception generate url', function () {
+    FintectureTester::mockResponses([
+        new Response(
+            status: 400,
+            body: json_encode(['status' => '400', 'errors' => [
+                [
+                    'code' => 'mock_error_code',
+                    'title' => 'mock_error_title',
+                    'message' => 'mock_error_message',
+                ],
+            ]])
         ),
     ]);
 
     $url = Fintecture::generate();
 
     expect($url)->toBe('https://mock.url/fintecture');
-});
+})->throws(FintectureException::class, 'mock_error_message');


### PR DESCRIPTION
Replace error message echoes with exceptions for token generation and connection failures. Refactor tests to enhance clarity and ensure proper exception handling.