### PR TITLE
Add Currency enum and refactor payment data structures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "illuminate/contracts": "^10.0||^11.0||^12.0",
         "spatie/laravel-data": "^4.17",
         "spatie/laravel-package-tools": "^1.16",
-        "wendelladriel/laravel-validated-dto": "^4.2"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.7",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "fintecture/fintecture-sdk-php": "^2.6",
         "illuminate/contracts": "^10.0||^11.0||^12.0",
         "spatie/laravel-data": "^4.17",
-        "spatie/laravel-package-tools": "^1.16",
+        "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "guzzlehttp/psr7": "^2.7",

--- a/src/Data/PaymentAttributesData.php
+++ b/src/Data/PaymentAttributesData.php
@@ -2,6 +2,9 @@
 
 namespace Bnzo\Fintecture\Data;
 
+use Bnzo\Fintecture\Enums\Currency;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Casts\EnumCast;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Optional;
 
@@ -9,7 +12,8 @@ class PaymentAttributesData extends Data
 {
     public function __construct(
         public string $amount,
-        public string $currency,
+        #[WithCast(EnumCast::class, Currency::class)]
+        public ?Currency $currency = Currency::EUR,
         public string|Optional|null $communication = null,
     ) {}
 }

--- a/src/Data/PaymentSettingsData.php
+++ b/src/Data/PaymentSettingsData.php
@@ -14,9 +14,9 @@ class PaymentSettingsData extends Data
         public ?bool $permanent,
         public int $expiry = 84000,
         public int $due_date = 84000,
-        #[WithCast(EnumCast::class)]
+        #[WithCast(EnumCast::class, ScheduledExpirationPolicy::class)]
         public ScheduledExpirationPolicy $scheduled_expiration_policy = ScheduledExpirationPolicy::Immediate,
-        #[WithCast(EnumCast::class)]
+        #[WithCast(EnumCast::class, Method::class)]
         public Method $method = Method::Link,
     ) {
         $this->permanent = $permanent ?: false;

--- a/src/Enums/Currency.php
+++ b/src/Enums/Currency.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bnzo\Fintecture\Enums;
+
+enum Currency: string
+{
+    case EUR = 'EUR';
+    case USD = 'USD';
+    case GBP = 'GBP';
+    case JPY = 'JPY';
+    case CHF = 'CHF';
+    case CAD = 'CAD';
+    case AUD = 'AUD';
+    case CNY = 'CNY';
+
+    // Add more as needed, full ISO 4217 list is ~180 currencies.
+
+    public function symbol(): string
+    {
+        return match ($this) {
+            self::EUR => '€',
+            self::USD => '$',
+            self::GBP => '£',
+            self::JPY => '¥',
+            self::CHF => 'CHF',
+            self::CAD => 'CA$',
+            self::AUD => 'A$',
+            self::CNY => '¥',
+        };
+    }
+
+    public function numericCode(): int
+    {
+        return match ($this) {
+            self::EUR => 978,
+            self::USD => 840,
+            self::GBP => 826,
+            self::JPY => 392,
+            self::CHF => 756,
+            self::CAD => 124,
+            self::AUD => 36,
+            self::CNY => 156,
+        };
+    }
+}

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -7,7 +7,7 @@ use Fintecture\Util\FintectureException;
 use GuzzleHttp\Psr7\Response;
 
 beforeEach(function () {
-    $this->PaymentDTO = PaymentRequestData::from([
+    $this->PaymentRequestData = PaymentRequestData::from([
         'meta' => [
             'psu_name' => 'Julien Lefebvre',
             'psu_email' => 'julien.lefebre@my-business-sarl.com',
@@ -15,7 +15,6 @@ beforeEach(function () {
         'data' => [
             'attributes' => [
                 'amount' => '272.00',
-                'currency' => 'EUR',
                 'communication' => 'test',
             ],
         ],
@@ -32,7 +31,7 @@ it('can generate url', function () {
         ),
     ], );
 
-    $paymentResponseData = Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentDTO);
+    $paymentResponseData = Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentRequestData);
 
     expect($paymentResponseData->url)->toBe('https://mock.url/fintecture');
     expect($paymentResponseData->sessionId)->toBe('mock_session_id');
@@ -52,6 +51,6 @@ it('can throw an exception generate url', function () {
         ),
     ]);
 
-    Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentDTO);
+    Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentRequestData);
 
 })->throws(FintectureException::class, 'mock_error_message');


### PR DESCRIPTION
Introduce a Currency enum to standardize currency representation and refactor related data structures to utilize this enum. Update tests to reflect changes in naming and structure, removing unnecessary dependencies.