### PR TITLE
Refactor test execution and improve readability

### DIFF
--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -33,8 +33,6 @@ it('can generate url', function () {
         ),
     ], );
 
-    eval(\Psy\sh());
-
     $paymentResponseData = Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentRequestData);
 
     expect($paymentResponseData->url)->toBe('https://mock.url/fintecture');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,9 @@
 <?php
 
 use Bnzo\Fintecture\Tests\TestCase;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 
-uses(TestCase::class)->in(__DIR__);
+pest()
+    ->extend(TestCase::class)
+    ->use(LazilyRefreshDatabase::class)
+    ->in(__DIR__);


### PR DESCRIPTION
Remove the eval statement from GenerateTest for cleaner execution and refactor Pest.php to utilize pest() syntax, enhancing readability and maintainability.