### PR TITLE
Refactor PaymentAttributesData for clarity and simplicity

### DIFF
--- a/src/Data/PaymentAttributesData.php
+++ b/src/Data/PaymentAttributesData.php
@@ -11,8 +11,8 @@ class PaymentAttributesData extends Data
 {
     public function __construct(
         public string $amount,
-        #[WithCast(EnumCast::class, Currency::class)]
         public string $communication,
+        #[WithCast(EnumCast::class, Currency::class)]
         public ?Currency $currency = Currency::EUR,
     ) {}
 }

--- a/src/Data/PaymentAttributesData.php
+++ b/src/Data/PaymentAttributesData.php
@@ -6,16 +6,13 @@ use Bnzo\Fintecture\Enums\Currency;
 use Spatie\LaravelData\Attributes\WithCast;
 use Spatie\LaravelData\Casts\EnumCast;
 use Spatie\LaravelData\Data;
-use Spatie\LaravelData\Optional;
 
 class PaymentAttributesData extends Data
 {
     public function __construct(
         public string $amount,
         #[WithCast(EnumCast::class, Currency::class)]
+        public string $communication,
         public ?Currency $currency = Currency::EUR,
-        public string|Optional|null $communication = null,
-    ) {
-        $this->communication = $communication ?: Optional::create();
-    }
+    ) {}
 }


### PR DESCRIPTION
Simplify the initialization of the communication property in PaymentAttributesData and improve the constructor parameter order for better clarity.