### PR TITLE
Refactor Fintecture generate method to remove state parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ $paymentData = new PaymentRequestData(
     );
 
 $paymentResponseData = Fintecture::generate(
-    state: 'state', 
-    redirectUri: 'https://redirect.uri', 
     paymentData: $paymentData
+    redirectUri: 'https://redirect.uri', 
 );
 
 $paymentResponseData->url; //https://fintecture.com/v2/85b0a547-5c18-4a16-b93b-2a4f5f03127d
@@ -83,8 +82,8 @@ use Bnzo\Fintecture\Data\PaymentRequestData;
 $paymentRequestData = new PaymentRequestData(
     new PaymentAttributesData(
         amount: '272.00',
-        currency: Currency::EUR, // default EUR
         communication: 'test',
+        currency: Currency::EUR, // default EUR
     ),
     new PaymentCustomerData(
         psu_email: 'julien.lefebre@my-business-sarl.com',

--- a/src/Fintecture.php
+++ b/src/Fintecture.php
@@ -34,14 +34,14 @@ class Fintecture
         $this->pisClient->setAccessToken($pisToken);
     }
 
-    public function generate(string $state, string $redirectUri, PaymentRequestData $paymentData): PaymentResponseData
+    public function generate(PaymentRequestData $paymentData, ?string $redirectUri = null): PaymentResponseData
     {
         $this->setAccessToken();
 
         $connect = $this->pisClient->connect->generate(
             data: $paymentData->toArray(),
-            state: $state,
-            redirectUri: $redirectUri, // replace with your redirect URI
+            state: $paymentData->attributes->communication,
+            redirectUri: $redirectUri,
         );
         if (! $connect->error) {
             return PaymentResponseData::from((array) $connect->result->meta);

--- a/tests/AuthTest.php
+++ b/tests/AuthTest.php
@@ -20,7 +20,7 @@ it('can throw an exception if token generation fails', function () {
         ),
     ], withToken: false);
 
-    $url = Fintecture::generate('mock_state', 'https://mock.redirect.uri', PaymentRequestData::from([
+    $url = Fintecture::generate(PaymentRequestData::from([
         'meta' => [
             'psu_name' => 'Julien Lefebvre',
             'psu_email' => 'julien.lefebre@my-business-sarl.com',

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -33,7 +33,7 @@ it('can generate url', function () {
         ),
     ], );
 
-    $paymentResponseData = Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentRequestData);
+    $paymentResponseData = Fintecture::generate($this->PaymentRequestData);
 
     expect($paymentResponseData->url)->toBe('https://mock.url/fintecture');
     expect($paymentResponseData->sessionId)->toBe('mock_session_id');
@@ -53,7 +53,7 @@ it('can throw an exception generate url', function () {
         ),
     ]);
 
-    Fintecture::generate('mock_state', 'https://mock.redirect.uri', $this->PaymentRequestData);
+    Fintecture::generate($this->PaymentRequestData);
 
 })->throws(FintectureException::class, 'mock_error_message');
 


### PR DESCRIPTION
Remove the state parameter from the Fintecture generate method and update related tests accordingly. This change simplifies the method signature and improves code clarity.