### PR TITLE
Refactor SettingsData to use Carbon for date handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ $paymentRequestData = new PaymentData(
         ),
     ),
     new SettingsData(
-        due_date: 86400, // default 84000
-        expiry: 86400, // default 84000
+        dueAt: now()->addDay(), // default 24h
+        expiresAt: now()->addDay(), // default 24h
         method: Method::Link // default Link
         permanent: false, // default false
         redirectUri: "https://myapp.test/finctecture/callback" //default null

--- a/src/Data/ConfigData.php
+++ b/src/Data/ConfigData.php
@@ -33,12 +33,4 @@ class ConfigData extends Data
             'environment' => ['string', 'in:sandbox,production'],
         ];
     }
-
-    protected function casts(): array
-    {
-        return [
-            'privateKey' => new Base64PrivateKeyCast,
-            'environment' => new EnumCast(Environment::class),
-        ];
-    }
 }

--- a/src/Data/SettingsData.php
+++ b/src/Data/SettingsData.php
@@ -29,11 +29,11 @@ class SettingsData extends Data
         #[MapOutputName('expiry')]
         public ?Carbon $expiresAt = null,
         #[WithCast(EnumCast::class, Method::class)]
-        public ?Method $method = Method::Link,
-        public ?bool $permanent = false,
+        public ?Method $method = null,
+        public ?bool $permanent = null,
         public string|Optional|null $redirectUri = null,
         #[WithCast(EnumCast::class, ScheduledExpirationPolicy::class)]
-        public ScheduledExpirationPolicy $scheduled_expiration_policy = ScheduledExpirationPolicy::Immediate,
+        public ?ScheduledExpirationPolicy $scheduled_expiration_policy = null,
     ) {
         $this->dueAt = $dueAt ?: now()->addHours(24);
         $this->expiresAt = $expiresAt ?: now()->addHours(24);

--- a/src/Data/SettingsData.php
+++ b/src/Data/SettingsData.php
@@ -4,7 +4,13 @@ namespace Bnzo\Fintecture\Data;
 
 use Bnzo\Fintecture\Enums\Method;
 use Bnzo\Fintecture\Enums\ScheduledExpirationPolicy;
+use Bnzo\Fintecture\Transformers\CarbonDiffInSecondsTransformer;
+use Illuminate\Support\Carbon;
+use Spatie\LaravelData\Attributes\MapInputName;
+use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Attributes\WithTransformer;
+use Spatie\LaravelData\Casts\DateTimeInterfaceCast;
 use Spatie\LaravelData\Casts\EnumCast;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\Optional;
@@ -12,16 +18,29 @@ use Spatie\LaravelData\Optional;
 class SettingsData extends Data
 {
     public function __construct(
-        public int $due_date = 86400,
-        public int $expiry = 86400,
+        #[WithCast(DateTimeInterfaceCast::class, 'Y-m-d H:i:s')]
+        #[WithTransformer(CarbonDiffInSecondsTransformer::class)]
+        #[MapInputName('due_date')]
+        #[MapOutputName('due_date')]
+        public ?Carbon $dueAt = null,
+        #[WithCast(DateTimeInterfaceCast::class, 'Y-m-d H:i:s')]
+        #[WithTransformer(CarbonDiffInSecondsTransformer::class)]
+        #[MapInputName('expiry')]
+        #[MapOutputName('expiry')]
+        public ?Carbon $expiresAt = null,
         #[WithCast(EnumCast::class, Method::class)]
-        public Method $method = Method::Link,
-        public bool $permanent = false,
+        public ?Method $method = Method::Link,
+        public ?bool $permanent = false,
         public string|Optional|null $redirectUri = null,
         #[WithCast(EnumCast::class, ScheduledExpirationPolicy::class)]
         public ScheduledExpirationPolicy $scheduled_expiration_policy = ScheduledExpirationPolicy::Immediate,
     ) {
+        $this->dueAt = $dueAt ?: now()->addHours(24);
+        $this->expiresAt = $expiresAt ?: now()->addHours(24);
+        $this->method = $method ?: Method::Link;
         $this->permanent = $permanent ?: false;
         $this->redirectUri = $redirectUri ?: Optional::create();
+        $this->scheduled_expiration_policy = $scheduled_expiration_policy ?: ScheduledExpirationPolicy::Immediate;
+
     }
 }

--- a/src/Transformers/CarbonDiffInSecondsTransformer.php
+++ b/src/Transformers/CarbonDiffInSecondsTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Bnzo\Fintecture\Transformers;
+
+use Illuminate\Support\Carbon;
+use Spatie\LaravelData\Support\DataProperty;
+use Spatie\LaravelData\Support\Transformation\TransformationContext;
+use Spatie\LaravelData\Transformers\Transformer;
+
+class CarbonDiffInSecondsTransformer implements Transformer
+{
+    public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
+    {
+        if ($value instanceof Carbon) {
+            return (int) abs($value->diffInSeconds(now()));
+        }
+
+        return null;
+    }
+}

--- a/tests/DataObjects/SettingsDataTest.php
+++ b/tests/DataObjects/SettingsDataTest.php
@@ -6,5 +6,7 @@ it('setting', function () {
         expiresAt: now()->addHours(24),
     );
 
-    eval(\Psy\sh());
+    expect($settingsData->toArray()['due_date'])
+        ->toBeLessThanOrEqual(86400)
+        ->toBeGreaterThan(86300);
 });

--- a/tests/DataObjects/SettingsDataTest.php
+++ b/tests/DataObjects/SettingsDataTest.php
@@ -1,0 +1,10 @@
+<?php
+
+it('setting', function () {
+    $settingsData = new \Bnzo\Fintecture\Data\SettingsData(
+        dueAt: now()->addHours(24),
+        expiresAt: now()->addHours(24),
+    );
+
+    eval(\Psy\sh());
+});

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -81,8 +81,8 @@ it('generate data', function () {
             )
         ),
         new SettingsData(
-            expiry: 86400,
-            due_date: 86400,
+            expiresAt: now()->addHours(24),
+            dueAt: now()->addHours(24),
             permanent: false,
             scheduled_expiration_policy: ScheduledExpirationPolicy::Immediate,
             method: Method::Link,


### PR DESCRIPTION
Update the SettingsData class to utilize Carbon for due and expiry dates, enhancing date management. Introduce a transformer to calculate time differences in seconds and add initial tests for the new functionality. Clean up unused methods in the ConfigData class.