### PR TITLE
Refactor date properties to use DateTime instead of Carbon

### DIFF
--- a/src/Data/SettingsData.php
+++ b/src/Data/SettingsData.php
@@ -5,7 +5,7 @@ namespace Bnzo\Fintecture\Data;
 use Bnzo\Fintecture\Enums\Method;
 use Bnzo\Fintecture\Enums\ScheduledExpirationPolicy;
 use Bnzo\Fintecture\Transformers\CarbonDiffInSecondsTransformer;
-use Illuminate\Support\Carbon;
+use DateTime;
 use Spatie\LaravelData\Attributes\MapInputName;
 use Spatie\LaravelData\Attributes\MapOutputName;
 use Spatie\LaravelData\Attributes\WithCast;
@@ -22,12 +22,12 @@ class SettingsData extends Data
         #[WithTransformer(CarbonDiffInSecondsTransformer::class)]
         #[MapInputName('due_date')]
         #[MapOutputName('due_date')]
-        public ?Carbon $dueAt = null,
+        public ?DateTime $dueAt = null,
         #[WithCast(DateTimeInterfaceCast::class, 'Y-m-d H:i:s')]
         #[WithTransformer(CarbonDiffInSecondsTransformer::class)]
         #[MapInputName('expiry')]
         #[MapOutputName('expiry')]
-        public ?Carbon $expiresAt = null,
+        public ?DateTime $expiresAt = null,
         #[WithCast(EnumCast::class, Method::class)]
         public ?Method $method = null,
         public ?bool $permanent = null,

--- a/src/Transformers/CarbonDiffInSecondsTransformer.php
+++ b/src/Transformers/CarbonDiffInSecondsTransformer.php
@@ -2,6 +2,7 @@
 
 namespace Bnzo\Fintecture\Transformers;
 
+use DateTimeInterface;
 use Illuminate\Support\Carbon;
 use Spatie\LaravelData\Support\DataProperty;
 use Spatie\LaravelData\Support\Transformation\TransformationContext;
@@ -9,9 +10,12 @@ use Spatie\LaravelData\Transformers\Transformer;
 
 class CarbonDiffInSecondsTransformer implements Transformer
 {
-    public function transform(DataProperty $property, mixed $value, TransformationContext $context): mixed
+    public function transform(DataProperty $property, mixed $value, TransformationContext $context): ?int
     {
-        if ($value instanceof Carbon) {
+        if ($value instanceof DateTimeInterface) {
+            // Convert to Carbon for uniform handling
+            $value = $value instanceof Carbon ? $value : Carbon::instance($value);
+
             return (int) abs($value->diffInSeconds(now()));
         }
 


### PR DESCRIPTION
Update SettingsData to utilize DateTime for date properties and modify CarbonDiffInSecondsTransformer to support DateTimeInterface, ensuring consistent date handling.