### PR TITLE
Implement cancelPayment method with tests

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Bnzo\Fintecture\Events\PaymentCreated;
 use Bnzo\Fintecture\Events\PaymentUnsuccessful;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\URL;
 
 Route::prefix('fintecture')->group(function () {
     Route::post('/webhook', function (Request $request) {
@@ -20,4 +21,10 @@ Route::prefix('fintecture')->group(function () {
             default => null,
         };
     });
+});
+
+Route::domain('console.fintecture.com')->group(function () {
+    URL::forceScheme('https');
+    Route::get(
+        '/payments/detail/'.config('fintecture.environment').'/{sessionId}', function ($sessionId) {})->name('fintecture.console');
 });

--- a/src/Enums/PaymentStatus.php
+++ b/src/Enums/PaymentStatus.php
@@ -6,6 +6,7 @@ enum PaymentStatus: string
 {
     case PaymentCreated = 'payment_created';
     case PaymentPending = 'payment_pending';
+    case PaymentCancelled = 'payment_cancelled';
     case PaymentUnsuccessful = 'payment_unsuccessful';
     case PaymentError = 'payment_error';
     case ScaRequired = 'sca_required';

--- a/tests/CancelPaymentTest.php
+++ b/tests/CancelPaymentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Bnzo\Fintecture\Data\PaymentData;
+use Bnzo\Fintecture\Facades\Fintecture;
+use Bnzo\Fintecture\Tests\FintectureTester;
+use GuzzleHttp\Psr7\Response;
+
+beforeEach(function () {
+    $this->PaymentRequestData = PaymentData::from([
+        'meta' => [
+            'psu_name' => 'Julien Lefebvre',
+            'psu_email' => 'julien.lefebre@my-business-sarl.com',
+        ],
+        'data' => [
+            'attributes' => [
+                'amount' => '272.00',
+                'communication' => 'test',
+            ],
+        ],
+    ]);
+});
+
+it('can cancel payment', function () {
+    FintectureTester::mockResponses([
+        new Response(
+            body: json_encode(['meta' => [
+                'session_id' => '22db841679424e0dac5714ddefdbbfbe',
+                'status' => 'payment_cancelled',
+            ]])
+        ),
+    ], );
+
+    $paymentResponseData = Fintecture::cancelPayment('22db841679424e0dac5714ddefdbbfbe');
+    expect($paymentResponseData)->toBeTrue();
+});

--- a/tests/ConsoleRouteTest.php
+++ b/tests/ConsoleRouteTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Bnzo\Fintecture\Data\PaymentData;
+
+beforeEach(function () {
+    $this->PaymentRequestData = PaymentData::from([
+        'meta' => [
+            'psu_name' => 'Julien Lefebvre',
+            'psu_email' => 'julien.lefebre@my-business-sarl.com',
+        ],
+        'data' => [
+            'attributes' => [
+                'amount' => '272.00',
+                'communication' => 'test',
+            ],
+        ],
+    ]);
+});
+
+it('can route to console', function () {
+    $url = route('fintecture.console', ['sessionId' => '91b804d5e316428f8287874ae45ba7a8']);
+    expect($url)->toBe('https://console.fintecture.com/payments/detail/sandbox/91b804d5e316428f8287874ae45ba7a8');
+});


### PR DESCRIPTION
Add a method to cancel payments and include a corresponding test case to verify its functionality. Update the PaymentStatus enum to reflect the new cancelled state.