### PR TITLE
Refactor SettingsData and update GenerateTest usage

### DIFF
--- a/src/Data/SettingsData.php
+++ b/src/Data/SettingsData.php
@@ -22,25 +22,24 @@ class SettingsData extends Data
         #[WithTransformer(CarbonDiffInSecondsTransformer::class)]
         #[MapInputName('due_date')]
         #[MapOutputName('due_date')]
-        public ?DateTimeInterface $dueAt = null,
+        public DateTimeInterface|Optional|null $dueAt = null,
         #[WithCast(DateTimeInterfaceCast::class, 'Y-m-d H:i:s')]
         #[WithTransformer(CarbonDiffInSecondsTransformer::class)]
         #[MapInputName('expiry')]
         #[MapOutputName('expiry')]
-        public ?DateTimeInterface $expiresAt = null,
+        public DateTimeInterface|Optional|null $expiresAt = null,
         #[WithCast(EnumCast::class, Method::class)]
-        public ?Method $method = null,
-        public ?bool $permanent = null,
+        public Method|Optional|null $method = null,
+        public bool|Optional|null $permanent = null,
         public string|Optional|null $redirectUri = null,
         #[WithCast(EnumCast::class, ScheduledExpirationPolicy::class)]
-        public ?ScheduledExpirationPolicy $scheduled_expiration_policy = null,
+        public ScheduledExpirationPolicy|Optional|null $scheduled_expiration_policy = null,
     ) {
-        $this->dueAt = $dueAt ?: now()->addHours(24);
-        $this->expiresAt = $expiresAt ?: now()->addHours(24);
-        $this->method = $method ?: Method::Link;
-        $this->permanent = $permanent ?: false;
+        $this->dueAt = $dueAt ?: Optional::create();
+        $this->expiresAt = $expiresAt ?: Optional::create();
+        $this->method = $method ?: Optional::create();
+        $this->permanent = $permanent ?: Optional::create();
         $this->redirectUri = $redirectUri ?: Optional::create();
-        $this->scheduled_expiration_policy = $scheduled_expiration_policy ?: ScheduledExpirationPolicy::Immediate;
-
+        $this->scheduled_expiration_policy = $scheduled_expiration_policy ?: Optional::create();
     }
 }

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -13,20 +13,30 @@ use Fintecture\Util\FintectureException;
 use GuzzleHttp\Psr7\Response;
 
 beforeEach(function () {
-    $this->paymentData = PaymentData::from([
-        'meta' => [
-            'psu_name' => 'Julien Lefebvre',
-            'psu_email' => 'nbenzoni@agicom.fr',
-            'method' => 'email',
-        ],
-        'data' => [
-            'attributes' => [
-                'amount' => '272.00',
-                'communication' => 'test',
-                'language' => 'fr',
-            ],
-        ],
-    ]);
+    $this->paymentData = new PaymentData(
+        new AttributesData(
+            amount: '276.00',
+            communication: 'test',
+        ),
+        new CustomerData(
+            email: 'nbenzoni@agicom.fr',
+            name: 'Julien Lefebvre',
+            address: new AddressData(
+                number: '12',
+                complement: 'Apt 4B',
+                street: '123 Main St',
+                zip: '75001',
+                city: 'Paris',
+                country: 'FR'
+            )
+        ),
+        new SettingsData
+        // expiresAt: now()->addHours(24),
+        // dueAt: now()->addHours(24),
+        // permanent: true,
+        // scheduled_expiration_policy: ScheduledExpirationPolicy::Expire,
+        // method: Method::Email
+    );
 });
 
 it('can generate url', function () {


### PR DESCRIPTION
Refactor the SettingsData class to utilize new constructor parameters and update the GenerateTest to instantiate PaymentData with the new structure. This improves code clarity and consistency.